### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ for non-duplicate NIST hashes is >5GB.
 
 # Requirements
 
-pip install kyoto-cabinet
+- Make sure kyotocabinet is installed from your linux package repositories (e.g. on arch linux do ``pacman -S kyotocabinet``)
+- ``pip install kyotocabinet`` to generate the python bindings
 
 # Build the db
 


### PR DESCRIPTION
The installation did not work as the readme is currently explaining it.

- pip package is called kyotocabinet and not kyoto-cabinet
- its installation fails if the kyotocabinet package is not installed before the python bindings are installed